### PR TITLE
git prune command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,6 +94,12 @@
         "fix": [
             "@php vendor/bin/phpcbf || true",
             "composer test"
+        ],
+        "git-prune": [
+            "git branch -a",
+            "git fetch --prune",
+            "git branch | grep -v \"main\" | xargs git branch -d || true",
+            "git branch -a"
         ]
     },
     "conflict": {


### PR DESCRIPTION
Keep your local checkouts clean by running: "composer git-prune"

This will remove all local branches that have already been pushed to the repository or are merged/removed remotely.

Except the branch 'main' (and the current worktree will never be removed by default)

Also works when running this on another branch.